### PR TITLE
feat: add skip-draft option to skip notifications for draft PRs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
   slackBotToken:
     description: "slack bot token for messaging"
     required: true
-  skip-draft:
+  skipDraft:
     description: "skip notification for draft PRs"
     required: false
     default: 'false'

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,10 @@ inputs:
   slackBotToken:
     description: "slack bot token for messaging"
     required: true
+  skip-draft:
+    description: "skip notification for draft PRs"
+    required: false
+    default: 'false'
 runs:
   using: 'node16'
   main: 'index.js'

--- a/index.js
+++ b/index.js
@@ -90,7 +90,8 @@ const sendSlack = ({repoName, labels, title, url, email}) => {
                     pull_request: {
                         title,
                         html_url: prUrl,
-                        labels
+                        labels,
+                        draft
                     },
                     sender,
                     requested_reviewer: requestedReviewer,
@@ -101,6 +102,15 @@ const sendSlack = ({repoName, labels, title, url, email}) => {
                 }
             }
         } = github;
+
+        // Check if we should skip draft PRs
+        const skipDraft = core.getInput('skip-draft') === 'true';
+        
+        if (skipDraft && draft) {
+            core.info(`Skipping notification for draft PR: ${title} (${prUrl})`);
+            core.notice(`Skipping notification for draft PR: ${title} (${prUrl})`);
+            return;
+        }
 
         if (!requestedReviewer) {
             core.notice(`Failed: 'requested_reviewer' does not exist. Looks like you've requested a team review which is not yet supported. The team name is '${requestedTeam.name}'.`);

--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ const sendSlack = ({repoName, labels, title, url, email}) => {
         } = github;
 
         // Check if we should skip draft PRs
-        const skipDraft = core.getInput('skip-draft') === 'true';
+        const skipDraft = core.getInput('skipDraft') === 'true';
         
         if (skipDraft && draft) {
             core.info(`Skipping notification for draft PR: ${title} (${prUrl})`);


### PR DESCRIPTION
- Add skip-draft input parameter to action.yml (default: false)
- Add logic to skip notifications when PR is in draft state and skip-draft is enabled
- Maintain backward compatibility - draft PRs still get notifications by default
- Allow users to control draft PR notifications through action configuration